### PR TITLE
您的用户二话不说就给您扔了个性能炸弹

### DIFF
--- a/lib/util/dio_util.dart
+++ b/lib/util/dio_util.dart
@@ -2,7 +2,7 @@ import 'package:dio/dio.dart';
 
 var dio = new Dio(
   BaseOptions(
-    baseUrl: "http://122.4.254.30:7501/BusService",
+    baseUrl: "http://122.4.254.30:8088/BusService",
     connectTimeout: Duration(seconds: 60),
     sendTimeout: Duration(seconds: 60),
     receiveTimeout: Duration(seconds: 60),

--- a/lib/view/home/line/search/line_search.dart
+++ b/lib/view/home/line/search/line_search.dart
@@ -78,6 +78,29 @@ class _LineSearchState extends State<LineSearch> {
       return widget.filter(result.routeName, _criteria);
     }).toList();
 
+    // 对搜索结果进行排序
+    results.sort((a, b) {
+      // 提取数字和非数字部分进行比较
+      Match? aMatch = RegExp(r'(\d+)(\D*)').firstMatch(a.routeName);
+      Match? bMatch = RegExp(r'(\d+)(\D*)').firstMatch(b.routeName);
+
+      // 提取数字部分进行比较
+      int aValue = int.tryParse(aMatch?.group(1) ?? '0') ?? 0;
+      int bValue = int.tryParse(bMatch?.group(1) ?? '0') ?? 0;
+
+      // 提取非数字部分进行比较
+      String aNonNumericPart = aMatch?.group(2) ?? '';
+      String bNonNumericPart = bMatch?.group(2) ?? '';
+
+      // 先按数字部分升序排序，然后按非数字部分升序排序
+      int valueComparison = aValue.compareTo(bValue);
+      if (valueComparison == 0) {
+        return aNonNumericPart.compareTo(bNonNumericPart);
+      } else {
+        return valueComparison;
+      }
+    });
+
     return Scaffold(
       appBar: AppBar(
         title: TextField(


### PR DESCRIPTION
在直接搜1的情况下我们应该希望1路在最前方，其他的10路 11路依次排列，但修改前的代码却是直接使用了服务器返回的all route data排序进行直接展示，但服务器的数据并非顺序排序，这就会导致用户检索个位数车辆的时候非常困难，本次更新虽然算法没有经过深思熟虑，但效果达到了排序的效果。